### PR TITLE
Option to clamp fractional zoom to either nearest or higher zoom

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -146,7 +146,13 @@ export var GridLayer = Layer.extend({
 
 		// @option keepBuffer: Number = 2
 		// When panning the map, keep this many rows and columns of tiles before unloading them.
-		keepBuffer: 2
+		keepBuffer: 2,
+		
+		// @option zoomClamp: String = 'round'|'ceil'
+		// At fractional zoom levels, tiles can be scaled either up or down. 
+		// With zoomClamp = 'ceil', tiles are always scaled down giving sharper images but increasing download size.
+		// With zoomClamp = 'round', tiles are scaled up or down from the nearest integer zoom.
+		zoomClamp: 'round'
 	},
 
 	initialize: function (options) {
@@ -544,7 +550,11 @@ export var GridLayer = Layer.extend({
 	},
 
 	_setView: function (center, zoom, noPrune, noUpdate) {
-		var tileZoom = this._clampZoom(Math.round(zoom));
+		if (this.options.zoomClamp === 'ceil') {
+			var tileZoom = this._clampZoom(Math.ceil(zoom));
+		} else {
+			var tileZoom = this._clampZoom(Math.round(zoom));
+		}
 		if ((this.options.maxZoom !== undefined && tileZoom > this.options.maxZoom) ||
 		    (this.options.minZoom !== undefined && tileZoom < this.options.minZoom)) {
 			tileZoom = undefined;


### PR DESCRIPTION
This is a remake of PR #6034 by @boundaryfree. At fractional zoom levels, tiles have to be either scaled up or down. Currently, Leaflet scales to the nearest integer zoom which means that the tiles can be scaled up leading to blurry images. This is particularly important for non-geographic images, e.g., when Leaflet is used to display pyramids with the Zoomify or Deep Zoom plugins - the blurring is quite noticeable for high-quality images such as photographs! It can also important for vector drawings such as CAD drawings.

This PR adds an option for the user to specify whether to scale the tiles at fractional zoom to the nearest integer zoom (default), or always scale them down from the higher integer zoom (this gives sharper images but increases download size).

The issue of blurred tiles in Leaflet has been discussed a few times before, e.g.: 
https://stackoverflow.com/questions/40387914/force-leaflet-map-to-use-only-integer-zoom-levels-no-fractional-levels
https://github.com/Leaflet/Leaflet/issues/6068
https://github.com/Leaflet/Leaflet/issues/6069

Here is a relevant detailed discussion of the same issue in mapbox:
https://github.com/mapbox/mapbox-gl-js/issues/1030